### PR TITLE
Add OnFailureSchedulerCallback

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <maven.compiler.target>1.7</maven.compiler.target>
         <compiler.version>1.7</compiler.version>
 
-        <allure.version>1.5.0</allure.version>
+        <allure.version>1.5.2</allure.version>
         <cucumberjvm.version>1.2.5</cucumberjvm.version>
         <aspectj.version>1.8.4</aspectj.version>
     </properties>
@@ -121,6 +121,11 @@
             <artifactId>gherkin</artifactId>
             <version>2.12.2</version>
             <type>jar</type>
+        </dependency>
+        <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging-api</artifactId>
+            <version>1.1</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/ru/yandex/qatools/allure/cucumberjvm/AllureReporter.java
+++ b/src/main/java/ru/yandex/qatools/allure/cucumberjvm/AllureReporter.java
@@ -1,5 +1,6 @@
 package ru.yandex.qatools.allure.cucumberjvm;
 
+import ru.yandex.qatools.allure.cucumberjvm.callback.OnFailureCallback;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
@@ -40,6 +41,7 @@ import ru.yandex.qatools.allure.annotations.Stories;
 import ru.yandex.qatools.allure.annotations.TestCaseId;
 import ru.yandex.qatools.allure.config.AllureModelUtils;
 import ru.yandex.qatools.allure.events.*;
+import ru.yandex.qatools.allure.exceptions.AllureException;
 import ru.yandex.qatools.allure.model.DescriptionType;
 import ru.yandex.qatools.allure.model.SeverityLevel;
 import ru.yandex.qatools.allure.utils.AnnotationManager;
@@ -48,6 +50,9 @@ import ru.yandex.qatools.allure.utils.AnnotationManager;
  * Allure reporting plugin for cucumber-jvm
  */
 public class AllureReporter implements Reporter, Formatter {
+
+    protected static Class<? extends OnFailureCallback> callback;
+    protected static Object callbackResult;
 
     private static final List<String> SCENARIO_OUTLINE_KEYWORDS = Collections.synchronizedList(new ArrayList<String>());
 
@@ -152,7 +157,6 @@ public class AllureReporter implements Reporter, Formatter {
             annotations.add(testCaseId);
         }
 
-
         annotations.add(getFeaturesAnnotation(feature.getName()));
         annotations.add(getStoriesAnnotation(scenario.getName()));
         annotations.add(getDescriptionAnnotation(scenario.getDescription()));
@@ -217,6 +221,15 @@ public class AllureReporter implements Reporter, Formatter {
     public void result(Result result) {
         if (match != null) {
             if (FAILED.equals(result.getStatus())) {
+
+                if (callback != null) {
+                    try {
+                        callbackResult = callback.newInstance().call();
+                    } catch (InstantiationException | IllegalAccessException ex) {
+                        throw new AllureException("Could not initialize callback", ex);
+                    }
+                }
+
                 ALLURE_LIFECYCLE.fire(new StepFailureEvent().withThrowable(result.getError()));
                 ALLURE_LIFECYCLE.fire(new TestCaseFailureEvent().withThrowable(result.getError()));
                 currentStatus = FAILED;
@@ -245,7 +258,7 @@ public class AllureReporter implements Reporter, Formatter {
             this.match = (StepDefinitionMatch) match;
 
             Step step = extractStep(this.match);
-            synchronized (gherkinSteps){
+            synchronized (gherkinSteps) {
                 while (gherkinSteps.peek() != null && !isEqualSteps(step, gherkinSteps.peek())) {
                     fireCanceledStep(gherkinSteps.remove());
                 }
@@ -457,5 +470,27 @@ public class AllureReporter implements Reporter, Formatter {
         }
 
         return null;
+    }
+
+    /**
+     * Apply callback which will called on test failure It should be a class
+     * which implements {@link OnFailureCallback}. the call() method can return
+     * result which will be available via
+     * AllureReporter.getFailureCallbackResult() method.
+     *
+     * @param callbackClass
+     */
+    public static void applyFailureCallback(Class<? extends OnFailureCallback> callbackClass) {
+        callback = callbackClass;
+    }
+
+    /**
+     * Returns failure callback result or null
+     *
+     * @param <T> Any type to return
+     * @return Returns failure callback result or null
+     */
+    public static <T> T getFailureCallbackResult() {
+        return (T) callbackResult;
     }
 }

--- a/src/main/java/ru/yandex/qatools/allure/cucumberjvm/AllureReporter.java
+++ b/src/main/java/ru/yandex/qatools/allure/cucumberjvm/AllureReporter.java
@@ -222,13 +222,7 @@ public class AllureReporter implements Reporter, Formatter {
         if (match != null) {
             if (FAILED.equals(result.getStatus())) {
 
-                if (callback != null) {
-                    try {
-                        callbackResult = callback.newInstance().call();
-                    } catch (InstantiationException | IllegalAccessException ex) {
-                        throw new AllureException("Could not initialize callback", ex);
-                    }
-                }
+                this.excuteFailureCallback();
 
                 ALLURE_LIFECYCLE.fire(new StepFailureEvent().withThrowable(result.getError()));
                 ALLURE_LIFECYCLE.fire(new TestCaseFailureEvent().withThrowable(result.getError()));
@@ -492,5 +486,15 @@ public class AllureReporter implements Reporter, Formatter {
      */
     public static <T> T getFailureCallbackResult() {
         return (T) callbackResult;
+    }
+    
+    private void excuteFailureCallback() {
+        if (callback != null) {
+            try {
+                callbackResult = callback.newInstance().call();
+            } catch (InstantiationException | IllegalAccessException ex) {
+                throw new AllureException("Could not initialize callback", ex);
+            }
+        }
     }
 }

--- a/src/main/java/ru/yandex/qatools/allure/cucumberjvm/AllureReporter.java
+++ b/src/main/java/ru/yandex/qatools/allure/cucumberjvm/AllureReporter.java
@@ -71,7 +71,7 @@ public class AllureReporter implements Reporter, Formatter {
     private Feature feature;
     private StepDefinitionMatch match;
 
-    private LinkedList<Step> gherkinSteps = new LinkedList<>();
+    private final LinkedList<Step> gherkinSteps = new LinkedList<>();
 
     private String uid;
     private String currentStatus;

--- a/src/main/java/ru/yandex/qatools/allure/cucumberjvm/callback/OnFailureCallback.java
+++ b/src/main/java/ru/yandex/qatools/allure/cucumberjvm/callback/OnFailureCallback.java
@@ -1,0 +1,11 @@
+package ru.yandex.qatools.allure.cucumberjvm.callback;
+
+public interface OnFailureCallback<OnFailureSchedilerCallback, Object> {
+
+    /**
+     * Callback call method
+     *
+     * @return Callback result
+     */
+    public Object call();
+}

--- a/src/main/java/ru/yandex/qatools/allure/cucumberjvm/callback/OnFailureCallback.java
+++ b/src/main/java/ru/yandex/qatools/allure/cucumberjvm/callback/OnFailureCallback.java
@@ -1,6 +1,6 @@
 package ru.yandex.qatools.allure.cucumberjvm.callback;
 
-public interface OnFailureCallback<OnFailureSchedilerCallback, Object> {
+public interface OnFailureCallback<OnFailureCallback, Object> {
 
     /**
      * Callback call method


### PR DESCRIPTION
In reaction to #41 

Now it is possible to set failure callback in ```@Before``` method which will filre in case of test failed.
Usage example:

**Callback implementation**
```java
public class FailureCallback implements OnFailureCallback {
    @Override
    public Object call() {
        return 10;
    }
}
```

**Usage**

```java
import cucumber.api.java.After;
import cucumber.api.java.Before;

public calss StepDefinitions {
   @Before
    public void before() {
        AllureReporter.applyFailureCallback(FailureCallback.class);
    }

    @After
    public void after() {
        int result = AllureReporter.getFailureCallbackResult();
        Assert.assertEquals(10, result);
    }
}
```

So you can do everything tou want in call(method): attach screenshots, rotate logs, etc. And you always can get callback result in @After section
